### PR TITLE
Fix exam day message not updating when changing exams

### DIFF
--- a/src/newtab/newtab.js
+++ b/src/newtab/newtab.js
@@ -376,6 +376,7 @@ async function updateCountdown() {
 		countdownHoursElement.style = `--value:${timeRemaining.hours}`;
 		countdownMinutesElement.style = `--value:${timeRemaining.minutes}`;
 		countdownSecondsElement.style = `--value:${timeRemaining.seconds}`;
+		countdownLabelElement.textContent = "";
 	}
 }
 


### PR DESCRIPTION


Fixes #18

## Description
Fixed UI bug where "Exam Day Has Arrived!" message persisted when switching from past/current exam to future exam. Added `countdownLabelElement.textContent = "";` in `updateCountdown()` else block to reset message.

## Type of Change

- [x] Bug fix

## Changes

- Modified `src/newtab/newtab.js` (line 379)
- Single line addition for label reset

## Testing

- [x] Past/current exam → shows message
- [x] Switch to future exam → message clears immediately
- [x] No page refresh required

## Checklist

- [x] Self-reviewed code
- [x] No new warnings/errors
- [x] Tests pass

**Minimal change with maximum impact.**
closes #18 