### PR TITLE
Allow users to set precise time of a custom exam & Set current time as min input time

### DIFF
--- a/src/newtab/newtab.html
+++ b/src/newtab/newtab.html
@@ -19,7 +19,7 @@
 					<div id="current-date" class="text-sm opacity-80"></div>
 				</div>
 
-				<div class="group fixed top-2 left-2 flex flex-col items-end space-y-2">
+				<div class="group fixed top-2 left-2 flex flex-col items-end space-y-2 z-10">
 					<!-- Settings Icon -->
 					<div class="tooltip tooltip-right" data-tip="Open Settings Menu">
 						<button id="options-link" class="btn btn-circle bg-base-200 shadow-lg">

--- a/src/newtab/newtab.html
+++ b/src/newtab/newtab.html
@@ -190,7 +190,7 @@
 								</div>
 								<div class="form-control mb-3">
 									<div class="relative">
-										<input type="date" id="custom-exam-date" class="input input-bordered w-full focus:outline-none" />
+										<input type="datetime-local" id="custom-exam-date" class="input input-bordered w-full focus:outline-none" />
 									</div>
 								</div>
 							</div>

--- a/src/newtab/newtab.js
+++ b/src/newtab/newtab.js
@@ -26,10 +26,15 @@ function saveCustomExamData(name, date) {
 	customExamName = name || "Custom Exam";
 	customExamDate = date;
 
+	let dateValueToStore = null;
+    if (customExamDate && !isNaN(customExamDate.getTime())) {
+        dateValueToStore = customExamDate.toISOString(); 
+    }
+
 	try {
 		browser.storage.sync.set({
 			customExamName: customExamName,
-			customExamDate: customExamDate ? customExamDate.getTime() : null,
+			customExamDate: dateValueToStore,
 		});
 		return true;
 	} catch (error) {
@@ -457,6 +462,34 @@ function setupEventListeners() {
 	const prevWallpaperBtn = document.getElementById("prev-wallpaper");
 	const pauseWallpaperBtn = document.getElementById("pause-wallpaper");
 
+	function formatDateToLocalInputString(date) {
+	    if (!date || isNaN(date.getTime())) return "";
+
+	    const pad = (num) => num.toString().padStart(2, '0');
+
+	    const year = date.getFullYear();
+	    const month = pad(date.getMonth() + 1); // getMonth() is 0-indexed
+	    const day = pad(date.getDate());
+	    const hours = pad(date.getHours());
+	    const minutes = pad(date.getMinutes());
+
+	    return `${year}-${month}-${day}T${hours}:${minutes}`;
+	}
+
+	function getCurrentLocalDatetimeString() {
+		const now = new Date();
+		
+		const pad = (num) => num.toString().padStart(2, '0');
+
+		const year = now.getFullYear();
+		const month = pad(now.getMonth() + 1); // getMonth() is 0-indexed
+		const day = pad(now.getDate());
+		const hours = pad(now.getHours());
+		const minutes = pad(now.getMinutes());
+
+		return `${year}-${month}-${day}T${hours}:${minutes}`;
+	}
+
 	const showOptionsModal = function () {
 		browser.storage.sync.get().then((data) => {
 			const activeExam = data.activeExam || "jeeAdv";
@@ -475,6 +508,8 @@ function setupEventListeners() {
 				brightnessSlider.value = 0.4;
 			}
 			const customExam = getCustomExamData();
+			const minTime = getCurrentLocalDatetimeString();
+			customExamDateInput.min = minTime;
 
 			if (customExam.name) {
 				customExamNameInput.value = customExam.name;
@@ -483,7 +518,7 @@ function setupEventListeners() {
 			}
 
 			if (hasValidCustomExam()) {
-				customExamDateInput.value = customExam.date.toISOString().split("T")[0];
+				customExamDateInput.value = formatDateToLocalInputString(customExam.date);
 
 				const customExamStat = document.getElementById("custom-exam-stat");
 				const customExamStatTitle = document.getElementById("custom-exam-stat-title");
@@ -492,7 +527,13 @@ function setupEventListeners() {
 				if (customExamStat && customExamStatTitle && customExamStatDate) {
 					customExamStat.classList.remove("hidden");
 					customExamStatTitle.textContent = customExam.name;
-					customExamStatDate.textContent = customExam.date.toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric" });
+					customExamStatDate.textContent = customExam.date.toLocaleDateString("en-US", { 
+						year: "numeric", 
+						month: "long", 
+						day: "numeric",
+						hour: "numeric",   
+						minute: "2-digit"  
+					});
 				}
 			} else {
 				customExamDateInput.value = "";


### PR DESCRIPTION
## Description

Feature: Changed custom exam date input type to datetime-local. Stored this in storage, and displayed in local timezone. Closes #32 
Bug Fix: Set the current time as min time for the input.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## How Has This Been Tested?

- [x] In settings, create a custom exam with precise time
- [x] Try setting a past time

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

<img width="650" height="233" alt="image" src="https://github.com/user-attachments/assets/0a96ae2f-4703-4b8d-9096-745b00dc5a88" />