### PR TITLE
To add inline edit functionality for TODO list

### DIFF
--- a/src/newtab/quick-todo-ui.js
+++ b/src/newtab/quick-todo-ui.js
@@ -133,7 +133,7 @@ function createQuickTodoElement(todo) {
     input.value = todo.text;
     input.className =
       "text-sm flex-1 p-1 rounded bg-black/30 text-white border border-white/20";
-    div.replaceChild(input, textSpan);
+    textSpan.replaceWith(input);
 
     // Save and cancel buttons
     const saveBtn = document.createElement("button");

--- a/src/newtab/quick-todo-ui.js
+++ b/src/newtab/quick-todo-ui.js
@@ -3,6 +3,7 @@ import {
   addTodo,
   toggleTodo,
   deleteTodo,
+  updateTodo,
   getTodosStats,
 } from "../utils/todos.js";
 
@@ -112,6 +113,53 @@ function createQuickTodoElement(todo) {
     todo.text.length > 30 ? todo.text.substring(0, 30) + "..." : todo.text;
   textSpan.title = todo.text; // Show full text on hover
 
+  // Edit button
+  const editBtn = document.createElement("button");
+  editBtn.className =
+    "btn btn-ghost btn-circle btn-xs text-white/70 hover:text-blue-400 flex-shrink-0";
+  editBtn.title = "Edit todo";
+  editBtn.innerHTML = `
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" 
+         stroke-width="1.5" stroke="currentColor" class="w-3 h-3">
+      <path stroke-linecap="round" stroke-linejoin="round" 
+            d="M16.862 3.487a2.25 2.25 0 013.182 3.182L7.5 19.213H4.5v-3l12.362-12.726z" />
+    </svg>
+  `;
+
+  // Edit button click handler
+  editBtn.addEventListener("click", () => {
+    const input = document.createElement("input");
+    input.type = "text";
+    input.value = todo.text;
+    input.className =
+      "text-sm flex-1 p-1 rounded bg-black/30 text-white border border-white/20";
+    div.replaceChild(input, textSpan);
+
+    // Save and cancel buttons
+    const saveBtn = document.createElement("button");
+    saveBtn.innerHTML = "✔";
+    saveBtn.className = "btn btn-ghost btn-xs text-green-500 ml-1";
+    const cancelBtn = document.createElement("button");
+    cancelBtn.innerHTML = "✖";
+    cancelBtn.className = "btn btn-ghost btn-xs text-red-500 ml-1";
+
+    div.appendChild(saveBtn);
+    div.appendChild(cancelBtn);
+    editBtn.style.display = "none"; // hide edit icon while editing
+
+    saveBtn.addEventListener("click", async () => {
+      const newText = input.value.trim();
+      if (newText && newText !== todo.text) {
+        await updateTodo(todo.id, newText);
+      }
+      renderQuickTodos();
+    });
+
+    cancelBtn.addEventListener("click", () => {
+      renderQuickTodos();
+    });
+  });
+
   // Delete button
   const deleteBtn = document.createElement("button");
   deleteBtn.className =
@@ -129,6 +177,7 @@ function createQuickTodoElement(todo) {
 
   div.appendChild(checkbox);
   div.appendChild(textSpan);
+  div.appendChild(editBtn);
   div.appendChild(deleteBtn);
 
   return div;

--- a/src/newtab/quick-todo-ui.js
+++ b/src/newtab/quick-todo-ui.js
@@ -122,7 +122,7 @@ function createQuickTodoElement(todo) {
     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" 
          stroke-width="1.5" stroke="currentColor" class="w-3 h-3">
       <path stroke-linecap="round" stroke-linejoin="round" 
-            d="M16.862 3.487a2.25 2.25 0 013.182 3.182L7.5 19.213H4.5v-3l12.362-12.726z" />
+            d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0115.75 21H5.25A2.25 2.25 0 013 18.75V8.25A2.25 2.25 0 015.25 6H10" />
     </svg>
   `;
 
@@ -146,17 +146,35 @@ function createQuickTodoElement(todo) {
     div.appendChild(saveBtn);
     div.appendChild(cancelBtn);
     editBtn.style.display = "none"; // hide edit icon while editing
+    deleteBtn.style.display = "none"; // hide delete icon while editing
 
-    saveBtn.addEventListener("click", async () => {
+    // Focus input
+    input.focus();
+
+    // Save function
+    const saveChanges = async () => {
       const newText = input.value.trim();
       if (newText && newText !== todo.text) {
         await updateTodo(todo.id, newText);
       }
       renderQuickTodos();
-    });
+    };
 
+    // Save button click handler
+    saveBtn.addEventListener("click", saveChanges);
+
+    // Cancel button click handler
     cancelBtn.addEventListener("click", () => {
       renderQuickTodos();
+    });
+
+    // Keyboard shortcuts
+    input.addEventListener("keyup", async (e) => {
+      if (e.key === "Enter") {
+        await saveChanges();
+      } else if (e.key === "Escape") {
+        renderQuickTodos();
+      }
     });
   });
 

--- a/src/newtab/todo-ui.js
+++ b/src/newtab/todo-ui.js
@@ -159,7 +159,9 @@ function createTodoElement(todo) {
 
   // Edit button click handler
   editBtn.addEventListener("click", () => {
-    if (!todo.completed) {
+    if (todo.completed) {
+      showToast("Cannot edit completed todo", "info");
+    } else {
       const input = document.createElement("input");
       input.type = "text";
       input.value = todo.text;
@@ -195,6 +197,7 @@ function createTodoElement(todo) {
             renderTodos();
             showToast("Todo updated successfully!", "success");
           } catch (error) {
+            console.error("Failed to update todo:", error);
             showToast("Failed to update todo", "error");
           }
         } else {
@@ -229,8 +232,6 @@ function createTodoElement(todo) {
           showToast("Edit cancelled", "info");
         }
       });
-    } else {
-      showToast("Cannot edit completed todo", "info");
     }
   });
 

--- a/src/utils/todos.js
+++ b/src/utils/todos.js
@@ -122,3 +122,31 @@ export async function getTodosStats() {
     pending: todos.filter((t) => !t.completed).length,
   };
 }
+
+/**
+ * Update an existing todo by id
+ * @param {string} id - Todo ID
+ * @param {string} newText - Updated todo text
+ * @returns {Promise<boolean>} Success status
+ */
+export async function updateTodo(id, newText) {
+  if (!newText || newText.trim() === "") {
+    throw new Error("Todo text cannot be empty");
+  }
+
+  try {
+    const todos = await getTodos();
+    const index = todos.findIndex((t) => t.id === id);
+
+    if (index === -1) {
+      throw new Error("Todo not found");
+    }
+
+    todos[index].text = newText.trim();
+    await saveTodos(todos);
+    return true;
+  } catch (error) {
+    console.error("Error updating todo:", error);
+    return false;
+  }
+}


### PR DESCRIPTION
## Description
Hi, This PR introduces the ability to edit existing todo items directly from the list. Users can now correct typos or update the content of their todos without having to delete and recreate them, improving overall usability and flexibility.

Briefly describe the changes made in this pull request.
Each todo now includes an edit icon/button that, when clicked, switches the item into edit mode, allowing users to update the text inline. Users can then save (✔) their changes or cancel (✖) to revert to the original content. 

Closes #52 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Other (please describe):

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Manually tested in the browser
- [x] Verified successful project build with no errors or warnings 

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)
https://github.com/user-attachments/assets/72933f41-b275-470f-b79e-754fbfd03029


## Additional Notes
Please share any feedback or suggestions. I’m happy to update accordingly🚀.

